### PR TITLE
Fix compiler error

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const runAsyncGenerator = async (gen, stream) => {
       data = await data;
     }
     if (data.done) break;
-    const value = data.value;
+    let value = data.value;
     if (value && typeof value.then == 'function') {
       value = await value;
     }


### PR DESCRIPTION
Hi, this PR is to fix the following compiler error:
```
 > node_modules/stream-chain/index.js: error: Cannot assign to "value" because it is a constant
    27 │       value = await value;
       ╵       ~~~~~
      node_modules/stream-chain/index.js: note: "value" was declared a constant here
    25 │     const value = data.value;
       ╵           ~~~~~
```